### PR TITLE
bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,25 +27,3 @@ Standard
 </div>
 ```
 
-With Bootstrap tabs
-
-```html
-<script>
-    jQuery(document).ready(function() {
-        $('ul.nav-tabs').putsch({type: 'bootstrap-tab'});
-    })
-</script>
-
-<div class="container">
-    <ul class="nav nav-tabs">
-        <li><a href="/tab1-content.html" class="tab" data-toggle="tab" data-target=".tab-content1">Tab 1</a></li>
-        <li><a href="/tab2-content.html" class="tab" data-toggle="tab" data-target=".tab-content2">Tab 2</a></li>
-        <li><a href="#tab-content3" class="tab" data-toggle="tab">Tab 3</a></li>
-    </ul>
-
-    <div class="tab-content">
-        <div class="tab-pane active tab-content1 tab-content2">No tab selected</div>
-        <div class="tab-pane" id="tab-content3">Tab 3 static content</div>
-    </div>
-</div>
-```

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "putsch",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "homepage": "https://github.com/iamluc/putsch",
   "authors": [
     "iamluc <luc@vieillescazes.net>"

--- a/jquery.putsch.js
+++ b/jquery.putsch.js
@@ -24,6 +24,21 @@
     }
 
     initialize = function(settings) {
+
+        // make initial state available as a putsch event
+        if (isHistoryAvalaible()) {
+            var url = document.location.toString();
+
+            var state = {
+                source: 'putsch',
+                type: 'default',
+                container: settings.container,
+                url: url
+            };
+            window.history.replaceState(state, window.document.title, url);
+        }
+
+
         $(window).on('popstate', function(event) {
             popStateHandler(event, settings);
         });
@@ -67,7 +82,9 @@
                 defaultHandler.handleEvent(event, settings);
             });
 
-            $(window).on('putsch:popstate', defaultHandler.popState);
+            $(window)
+                .off('putsch:popstate') // make sure it only fires once
+                .on('putsch:popstate', defaultHandler.popState);
         },
 
         handleEvent: function(event, settings) {
@@ -135,7 +152,9 @@
                 window.history.replaceState(state, window.document.title, url);
             }
 
-            $(window).on('putsch:popstate', bootstrapHandler.popState);
+            $(window)
+                .off('putsch:popstate') // make sure it only fires once
+                .on('putsch:popstate', bootstrapHandler.popState);
         },
 
         handleEvent: function(event, settings) {

--- a/jquery.putsch.js
+++ b/jquery.putsch.js
@@ -3,6 +3,8 @@
     var initialized = false;
     var ignoreEvent = false;
 
+    var initialURL = document.location.href;
+    
     $.fn.putsch = function(options) {
         var settings = $.extend({
             type: null,
@@ -14,34 +16,31 @@
             initialize(settings);
         }
 
-        if ('bootstrap-tab' == settings.type) {
-            bootstrapHandler.configure(this, settings)
-        } else {
-            defaultHandler.configure(this, settings);
-        }
+        defaultHandler.configure(this, settings);
 
         return this;
     }
 
     initialize = function(settings) {
 
-        // make initial state available as a putsch event
+        $(window).on('popstate', function(event) {
+            event.preventDefault();
+            event.stopPropagation();
+            popStateHandler(event, settings);
+        });
+        
+        $(window).on('putsch:popstate', defaultHandler.popState);
+        
+        // we push current State, so it's reachable
         if (isHistoryAvalaible()) {
-            var url = document.location.toString();
-
             var state = {
                 source: 'putsch',
                 type: 'default',
                 container: settings.container,
-                url: url
-            };
-            window.history.replaceState(state, window.document.title, url);
+                url: document.location.href
+            }
+            window.history.pushState(state, window.document.title, document.location.href);
         }
-
-
-        $(window).on('popstate', function(event) {
-            popStateHandler(event, settings);
-        });
         initialized = true;
     }
 
@@ -49,8 +48,8 @@
         var state = event.originalEvent.state;
 
         if (state && state.source == 'putsch') {
-            var event = $.Event('putsch:popstate', {state: state, settings: settings});
-            $(window).trigger(event);
+            var ev= $.Event('putsch:popstate', {state: state, settings: settings});
+            $(window).trigger(ev);
         }
     }
 
@@ -60,12 +59,6 @@
             cache: false,
             type: 'get',
             success: function (html) {
-                // If response starts with a doctype tag, stop ajax and reload entire page (ie. redirection to login form)
-                // if (html.match(/^<!DOCTYPE html>/)) {
-                //     window.location.reload();
-                //     return false;
-                // }
-
                 $(container).html(html);
             },
         });
@@ -77,14 +70,12 @@
 
     defaultHandler = {
         configure: function(elts, settings) {
+            
             $(elts).on('click', function(event) {
                 event.preventDefault();
+                event.stopPropagation();
                 defaultHandler.handleEvent(event, settings);
             });
-
-            $(window)
-                .off('putsch:popstate') // make sure it only fires once
-                .on('putsch:popstate', defaultHandler.popState);
         },
 
         handleEvent: function(event, settings) {
@@ -103,7 +94,6 @@
                     container: container,
                     url: url
                 }
-
                 window.history.pushState(state, window.document.title, url);
             }
 
@@ -114,106 +104,11 @@
             var state = event.state;
             var settings = event.settings;
 
-            if (!state || state.source != 'putsch' || state.type != 'default') {
+            if (!state || state.source !== 'putsch' || state.type !== 'default') {
                 return;
             }
 
             settings.loader(state.url, state.container, settings);
-        }
-    }
-
-    bootstrapHandler = {
-        configure: function(elts, settings) {
-
-            $(elts).find('li a').on('show show.bs.tab', function(event) {
-                bootstrapHandler.handleEvent(event, settings);
-            });
-
-            // Init first state
-            if (isHistoryAvalaible() && !window.history.state) {
-                var url = null;
-                var container = null;
-
-                var $activeTab = $(elts).find('li.active a:first');
-                if ($activeTab.length) {
-                    var url = $activeTab.attr('href');
-                    var container = $activeTab.data('target');
-                    var content = $(container).html();
-                }
-
-                var state = {
-                    source: 'putsch',
-                    type: 'bootstrap-tab',
-                    initialState: true,
-                    selector: elts.selector,
-                    url: url,
-                    container: container
-                }
-                window.history.replaceState(state, window.document.title, url);
-            }
-
-            $(window)
-                .off('putsch:popstate') // make sure it only fires once
-                .on('putsch:popstate', bootstrapHandler.popState);
-        },
-
-        handleEvent: function(event, settings) {
-            if (ignoreEvent) {
-                return;
-            }
-
-            var $link     = $(event.target);
-            var url       = $link.attr('href');
-            var container = $link.data('target');
-
-            if (isHistoryAvalaible()) {
-                var nextState = {
-                    source: 'putsch',
-                    type: 'bootstrap-tab',
-                    container: container,
-                    url: url
-                }
-
-                var currentState = window.history.state;
-
-                if (nextState.source == currentState.source
-                    && nextState.type == currentState.type
-                    && nextState.container == currentState.container
-                    && nextState.url == currentState.url
-                    ) {
-                    return;
-                }
-
-                window.history.pushState(nextState, window.document.title, url);
-            }
-
-            if ($link.data('target')) {
-                settings.loader(url, container, settings);
-            }
-       },
-
-        popState: function (event) {
-            var state = event.state;
-            var settings = event.settings;
-
-            if (!state || state.source != 'putsch' || state.type != 'bootstrap-tab') {
-                return;
-            }
-
-            if (state.container) {
-                var $a = $('li a[data-target="'+state.container+'"]:first');
-
-                if ($a.length) {
-                    settings.loader(state.url, state.container, settings);
-                    ignoreEvent = true;
-                    $a.tab('show');
-                    ignoreEvent = false;
-                }
-            } else if (state.url) {
-                $('li a[href="'+state.url+'"]').tab('show');
-            } else {
-                $(state.selector).find('li.active').removeClass('active');
-            }
         }
     }
 


### PR DESCRIPTION
Replace initial state with a "putsch" source state, so it fires events correctly.
(Or else, getting back to initial state, won't be a "state.source == 'putsch'" and loader won¡t be fired.

If $.putsch is invoked more than once (for example rebinding on the resulting content), $(window).on('putsch:popstate') will be binded, every time. We better make sure it only fires once.
